### PR TITLE
Revert directly if a point is out of curve

### DIFF
--- a/snark-verifier/src/loader/evm/code.rs
+++ b/snark-verifier/src/loader/evm/code.rs
@@ -59,6 +59,7 @@ impl YulCode {
                             let y_square_eq_x_cube_plus_3:bool := eq(x_cube_plus_3, y_square)
                             valid := and(y_square_eq_x_cube_plus_3, valid)
                         }}
+                        if not(valid) {{ revert(0, 0) }}
                     }}
                     {}
                 }}


### PR DESCRIPTION
Should we revert call earlier if a point is out of curve? I think which may save some gas as it jumps out earlier rather than going through the func until the last success check.