### PR TITLE
chore: update dependencies

### DIFF
--- a/snark-verifier/Cargo.toml
+++ b/snark-verifier/Cargo.toml
@@ -11,13 +11,13 @@ num-integer = "0.1.45"
 num-traits = "0.2.15"
 rand = "0.8"
 hex = "0.4"
-halo2_curves = { git = "https://github.com/privacy-scaling-explorations/halo2curves", tag = "0.3.0", package = "halo2curves" }
+halo2_curves = { git = "https://github.com/privacy-scaling-explorations/halo2curves", tag = "0.3.1", package = "halo2curves" }
 
 # parallel
 rayon = { version = "1.5.3", optional = true }
 
 # system_halo2
-halo2_proofs = { git = "https://github.com/privacy-scaling-explorations/halo2", tag = "v2022_10_22", optional = true }
+halo2_proofs = { git = "https://github.com/privacy-scaling-explorations/halo2", tag = "v2023_01_20", optional = true }
 
 # loader_evm
 sha3 = { version = "0.10", optional = true }
@@ -27,7 +27,7 @@ rlp = { version = "0.5.2", default-features = false, features = ["std"], optiona
 revm = { version = "= 2.3.1", optional = true }
 
 # loader_halo2
-halo2_wrong_ecc = { git = "https://github.com/privacy-scaling-explorations/halo2wrong", tag = "v2022_10_22", package = "ecc", optional = true }
+halo2_wrong_ecc = { git = "https://github.com/privacy-scaling-explorations/halo2wrong", tag = "v2023_01_20", package = "ecc", optional = true }
 poseidon = { git = "https://github.com/privacy-scaling-explorations/poseidon", tag = "v2022_10_22", optional = true }
 
 [dev-dependencies]
@@ -35,7 +35,7 @@ rand_chacha = "0.3.1"
 paste = "1.0.7"
 
 # system_halo2
-halo2_wrong_ecc = { git = "https://github.com/privacy-scaling-explorations/halo2wrong", tag = "v2022_10_22", package = "ecc" }
+halo2_wrong_ecc = { git = "https://github.com/privacy-scaling-explorations/halo2wrong", tag = "v2023_01_20", package = "ecc" }
 
 # loader_evm
 crossterm = { version = "0.25" }

--- a/snark-verifier/src/system/halo2/test/kzg.rs
+++ b/snark-verifier/src/system/halo2/test/kzg.rs
@@ -2,6 +2,7 @@ use crate::{
     system::halo2::test::{read_or_create_srs, MainGateWithRange},
     util::arithmetic::{fe_to_limbs, CurveAffine, MultiMillerLoop},
 };
+use halo2_curves::serde::SerdeObject;
 use halo2_proofs::poly::{commitment::ParamsProver, kzg::commitment::ParamsKZG};
 use rand_chacha::{rand_core::SeedableRng, ChaCha20Rng};
 
@@ -23,7 +24,11 @@ pub fn setup<M: MultiMillerLoop>(k: u32) -> ParamsKZG<M> {
 }
 
 pub fn main_gate_with_range_with_mock_kzg_accumulator<M: MultiMillerLoop>(
-) -> MainGateWithRange<M::Scalar> {
+) -> MainGateWithRange<M::Scalar>
+where
+    M::G1Affine: SerdeObject,
+    M::G2Affine: SerdeObject,
+{
     let srs = read_or_create_srs(TESTDATA_DIR, 1, setup::<M>);
     let [g1, s_g1] = [srs.get_g()[0], srs.get_g()[1]].map(|point| point.coordinates().unwrap());
     MainGateWithRange::new(


### PR DESCRIPTION
Updates `Cargo.toml` to use some of the updates made to other [pse](https://github.com/privacy-scaling-explorations) repos. In particular updates dependencies: 

```bash
halo2_wrong_ecc -> v2023_01_20
halo2_proofs -> v2023_01_20
halo2curves -> 0.3.1
``` 
The recent serialization updates made in `halo2_proofs` require extra trait constraints to `main_gate_with_range_with_mock_kzg_accumulator` in  `snark-verifier/src/system/halo2/test/kzg.rs` in particular: 
```rust
M::G1Affine: SerdeObject
M::G2Affine: SerdeObject
```
where `M: MultiMillerLoop`. 

Tested the updates using `cargo test`. The tests that I could run locally passed. 

