### PR TITLE
Enable `util::hash::poseidon` only when `feature = loader_halo2`

### DIFF
--- a/snark-verifier/src/util/hash.rs
+++ b/snark-verifier/src/util/hash.rs
@@ -1,7 +1,9 @@
 //! Hash algorithms.
 
+#[cfg(feature = "loader_halo2")]
 mod poseidon;
 
+#[cfg(feature = "loader_halo2")]
 pub use crate::util::hash::poseidon::Poseidon;
 
 #[cfg(feature = "loader_evm")]


### PR DESCRIPTION
Resolves #26