### PR TITLE
Derive `num_instance` from `instances` in CircuitExt

### DIFF
--- a/snark-verifier-sdk/src/lib.rs
+++ b/snark-verifier-sdk/src/lib.rs
@@ -107,10 +107,7 @@ pub trait CircuitExt<F: Field>: Circuit<F> {
     fn instances(&self) -> Vec<Vec<F>>;
 
     fn num_instance(&self) -> Vec<usize> {
-        self.instances()
-            .iter()
-            .map(|inst| inst.len())
-            .collect::<Vec<usize>>()
+        self.instances().iter().map(Vec::len).collect()
     }
 
     fn accumulator_indices() -> Option<Vec<(usize, usize)>> {

--- a/snark-verifier-sdk/src/lib.rs
+++ b/snark-verifier-sdk/src/lib.rs
@@ -102,11 +102,16 @@ impl SnarkWitness {
 }
 
 pub trait CircuitExt<F: Field>: Circuit<F> {
-    /// Return the number of instances of the circuit.
+    /// Return the instances of the circuit.
     /// This may depend on extra circuit parameters but NOT on private witnesses.
-    fn num_instance(&self) -> Vec<usize>;
-
     fn instances(&self) -> Vec<Vec<F>>;
+
+    fn num_instance(&self) -> Vec<usize> {
+        self.instances()
+            .iter()
+            .map(|inst| inst.len())
+            .collect::<Vec<usize>>()
+    }
 
     fn accumulator_indices() -> Option<Vec<(usize, usize)>> {
         None


### PR DESCRIPTION
Currently, when a user wants to implement the CircuitExt trait they have to implement both `instances` and `num_instance` methods. However, in most cases, the `num_instance` can simply be derived using `instances`. This PR does that, so that a user only has to implement `instances` method. Though this still allows the user to implement `num_instance` manually they want to.