### PR TITLE
chore: fix typos

### DIFF
--- a/snark-verifier/src/verifier/plonk.rs
+++ b/snark-verifier/src/verifier/plonk.rs
@@ -2,7 +2,7 @@
 //! [`PlonkVerifier`] implemented and both are implemented assuming the used
 //! [`PolynomialCommitmentScheme`] has [atomic] or [split] accumulation scheme
 //! ([`PlonkVerifier`] is just [`PlonkSuccinctVerifier`] plus doing accumulator
-//! deciding then returns accept/reject as ouput).
+//! deciding then returns accept/reject as output).
 //!
 //! [PLONK]: https://eprint.iacr.org/2019/953
 //! [atomic]: https://eprint.iacr.org/2020/499
@@ -27,7 +27,7 @@ pub(crate) mod protocol;
 pub use proof::PlonkProof;
 pub use protocol::PlonkProtocol;
 
-/// Verifier that verifies the cheap part of PLONK and ouput the accumulator.
+/// Verifier that verifies the cheap part of PLONK and output the accumulator.
 #[derive(Debug)]
 pub struct PlonkSuccinctVerifier<AS, AE = PhantomData<AS>>(PhantomData<(AS, AE)>);
 
@@ -93,7 +93,7 @@ where
 }
 
 /// Verifier that first verifies the cheap part of PLONK, then decides
-/// accumulator and returns accept/reject as ouput.
+/// accumulator and returns accept/reject as output.
 #[derive(Debug)]
 pub struct PlonkVerifier<AS, AE = PhantomData<AS>>(PhantomData<(AS, AE)>);
 

--- a/snark-verifier/src/verifier/plonk/protocol.rs
+++ b/snark-verifier/src/verifier/plonk/protocol.rs
@@ -61,7 +61,7 @@ where
     )]
     /// Prover and verifier common initial state to write to transcript if any.
     pub transcript_initial_state: Option<L::LoadedScalar>,
-    /// Instance polynomials commiting key if any.
+    /// Instance polynomials committing key if any.
     pub instance_committing_key: Option<InstanceCommittingKey<C>>,
     /// Linearization strategy.
     pub linearization: Option<LinearizationStrategy>,


### PR DESCRIPTION
fix typos:
ouput->output
commiting ->committing 