### PR TITLE
fix: Bump `revm` to 3.5.0 and fix wasm compilation issue by disabling default features

### DIFF
--- a/snark-verifier/Cargo.toml
+++ b/snark-verifier/Cargo.toml
@@ -21,7 +21,7 @@ halo2_proofs = { git = "https://github.com/privacy-scaling-explorations/halo2", 
 
 # loader_evm
 sha3 = { version = "0.10", optional = true }
-revm = { version = "3.3.0", optional = true }
+revm = { version = "3.5.0", optional = true,   default-features = false }
 
 # loader_halo2
 halo2_wrong_ecc = { git = "https://github.com/privacy-scaling-explorations/halo2wrong", tag = "v2023_04_20", package = "ecc", optional = true }


### PR DESCRIPTION
The default features of `revm` are disabled to fix the wasm compilation issue. The dependency wouldn't be impacted since only `Address, B256, U256, U512` are used from the it.

 - Steps to reproduce the error 
```
cargo build --target wasm32-wasi
```
 > error[E0432]: unresolved imports `ckzg_blob_to_kzg_commitment`, `ckzg_compute_blob_kzg_proof`, `ckzg_compute_kzg_proof`, `ckzg_free_trusted_setup`, `ckzg_load_trusted_setup`, `ckzg_load_trusted_setup_file`, `ckzg_verify_blob_kzg_proof`, `ckzg_verify_blob_kzg_proof_batch`, `ckzg_verify_kzg_proof`
  --> /.cargo/registry/src/github.com-1ecc6299db9ec823/c-kzg-0.1.1/src/bindings/mod.rs:14:5
   |
14 |     ckzg_blob_to_kzg_commitment as blob_to_kzg_commitment,
   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ no external crate `ckzg_blob_to_kzg_commitment`
15 |     ckzg_compute_blob_kzg_proof as compute_blob_kzg_proof,
   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ no external crate `ckzg_compute_blob_kzg_proof`
16 |     ckzg_compute_kzg_proof as compute_kzg_proof, ckzg_free_trusted_setup as free_trusted_setup,
   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ no external crate `ckzg_free_trusted_setup`
   |     |
   |     no external crate `ckzg_compute_kzg_proof`
17 |     ckzg_load_trusted_setup as load_trusted_setup,
   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ no external crate `ckzg_load_trusted_setup`
18 |     ckzg_load_trusted_setup_file as load_trusted_setup_file,
   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ no external crate `ckzg_load_trusted_setup_file`
19 |     ckzg_verify_blob_kzg_proof as verify_blob_kzg_proof,
   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ no external crate `ckzg_verify_blob_kzg_proof`
20 |     ckzg_verify_blob_kzg_proof_batch as verify_blob_kzg_proof_batch,
   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ no external crate `ckzg_verify_blob_kzg_proof_batch`
21 |     ckzg_verify_kzg_proof as verify_kzg_proof,
   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ no external crate `ckzg_verify_kzg_proof`
error[E0425]: cannot find value `file_path_bytes` in this scope
   --> /.cargo/registry/src/github.com-1ecc6299db9ec823/c-kzg-0.1.1/src/bindings/mod.rs:177:38
    |
177 |         let file_path = CString::new(file_path_bytes)
    |                                      ^^^^^^^^^^^^^^^ not found in this scope
Some errors have detailed explanations: E0425, E0432.
For more information about an error, try `rustc --explain E0425`.
error: could not compile `c-kzg` due to 2 previous errors
warning: build failed, waiting for other jobs to finish...