### PR TITLE
Make KzgDecidingKey fields public

### DIFF
--- a/snark-verifier/src/pcs/kzg/decider.rs
+++ b/snark-verifier/src/pcs/kzg/decider.rs
@@ -4,11 +4,12 @@ use std::marker::PhantomData;
 /// KZG deciding key.
 #[derive(Debug, Clone, Copy)]
 pub struct KzgDecidingKey<M: MultiMillerLoop> {
-    svk: KzgSuccinctVerifyingKey<M::G1Affine>,
+    /// KZG succinct verifying key.
+    pub svk: KzgSuccinctVerifyingKey<M::G1Affine>,
     /// Generator on G2.
-    g2: M::G2Affine,
+    pub g2: M::G2Affine,
     /// Generator to the trusted-setup secret on G2.
-    s_g2: M::G2Affine,
+    pub s_g2: M::G2Affine,
     _marker: PhantomData<M>,
 }
 


### PR DESCRIPTION
Fixes #55.

This commit enables users to re-use more of snark-verifier code when implementing

```rust
impl AccumulationDecider<_, MyLoader> for KzgAs<_, _>
```

in order to define their own Loader and make it work with KZG10.

The field `svk` was already exported through `impl AsRef<KzgSuccinctVerifyingKey<M::G1Affine>>`, but this commit additionally defines it as `pub` for consistency with `g2` and `s_g2` fields.